### PR TITLE
[import label] change `_imports` suffix with `import_` prefix

### DIFF
--- a/src/main/java/ghidra_irx/ghidra_irxAnalyzer.java
+++ b/src/main/java/ghidra_irx/ghidra_irxAnalyzer.java
@@ -92,7 +92,7 @@ public class ghidra_irxAnalyzer extends AbstractAnalyzer {
                 String nameString = new String(namebytes).split("\0")[0];
 
                 try {
-                    tbl.createLabel(addr, nameString.concat("_imports"), SourceType.ANALYSIS);
+                    tbl.createLabel(addr, nameString.insert(0, "import_"), SourceType.ANALYSIS);
                 } catch (InvalidInputException e) {
                     return false;
                 }


### PR DESCRIPTION
Allows to keep all the labeled imports together on the left panel due to alphabetic ordering